### PR TITLE
Adding functionality to the Parking size button

### DIFF
--- a/app/src/main/java/com/example/parkingsystem/MainActivity.kt
+++ b/app/src/main/java/com/example/parkingsystem/MainActivity.kt
@@ -1,14 +1,26 @@
 package com.example.parkingsystem
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.example.parkingsystem.databinding.ActivityMainBinding
+import com.example.parkingsystem.mvp.contract.ParkingContract
+import com.example.parkingsystem.mvp.model.ParkingModel
+import com.example.parkingsystem.mvp.presenter.ParkingPresenter
+import com.example.parkingsystem.mvp.view.ParkingView
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
+    private lateinit var presenter: ParkingContract.Presenter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        presenter = ParkingPresenter(ParkingModel(), ParkingView(this))
+        setListener()
+    }
+    private fun setListener() {
+        binding.parkingSizeButton.setOnClickListener {
+            presenter.onParkingSizeButtonPressed()
+        }
     }
 }

--- a/app/src/main/java/com/example/parkingsystem/mvp/contract/ParkingContract.kt
+++ b/app/src/main/java/com/example/parkingsystem/mvp/contract/ParkingContract.kt
@@ -1,0 +1,15 @@
+package com.example.parkingsystem.mvp.contract
+
+interface ParkingContract {
+    interface Model {
+        fun getParkingSize(): Int
+    }
+
+    interface Presenter {
+        fun onParkingSizeButtonPressed()
+    }
+
+    interface View {
+        fun showParkingSizeMessage(parkingSize: Int)
+    }
+}

--- a/app/src/main/java/com/example/parkingsystem/mvp/model/ParkingModel.kt
+++ b/app/src/main/java/com/example/parkingsystem/mvp/model/ParkingModel.kt
@@ -1,0 +1,12 @@
+package com.example.parkingsystem.mvp.model
+
+import com.example.parkingsystem.mvp.contract.ParkingContract
+
+class ParkingModel : ParkingContract.Model {
+    private val parkingSize = PARKING_SIZE_DEFAULT
+    override fun getParkingSize(): Int = parkingSize
+
+    companion object {
+        private const val PARKING_SIZE_DEFAULT = 10
+    }
+}

--- a/app/src/main/java/com/example/parkingsystem/mvp/presenter/ParkingPresenter.kt
+++ b/app/src/main/java/com/example/parkingsystem/mvp/presenter/ParkingPresenter.kt
@@ -1,0 +1,12 @@
+package com.example.parkingsystem.mvp.presenter
+
+import com.example.parkingsystem.mvp.contract.ParkingContract
+
+class ParkingPresenter(
+    private val model: ParkingContract.Model,
+    private val view: ParkingContract.View
+) : ParkingContract.Presenter {
+    override fun onParkingSizeButtonPressed() {
+        view.showParkingSizeMessage(model.getParkingSize())
+    }
+}

--- a/app/src/main/java/com/example/parkingsystem/mvp/view/ParkingView.kt
+++ b/app/src/main/java/com/example/parkingsystem/mvp/view/ParkingView.kt
@@ -1,0 +1,17 @@
+package com.example.parkingsystem.mvp.view
+
+import android.app.Activity
+import android.widget.Toast
+import com.example.parkingsystem.R
+import com.example.parkingsystem.mvp.contract.ParkingContract
+import com.example.parkingsystem.mvp.view.base.ActivityView
+
+class ParkingView(activity: Activity) : ParkingContract.View, ActivityView(activity) {
+    override fun showParkingSizeMessage(parkingSize: Int) {
+        Toast.makeText(
+            context,
+            context?.getString(R.string.text_parking_size_toast, parkingSize),
+            Toast.LENGTH_LONG
+        ).show()
+    }
+}

--- a/app/src/main/java/com/example/parkingsystem/mvp/view/base/ActivityView.kt
+++ b/app/src/main/java/com/example/parkingsystem/mvp/view/base/ActivityView.kt
@@ -1,0 +1,16 @@
+package com.example.parkingsystem.mvp.view.base
+
+import android.app.Activity
+import android.content.Context
+import java.lang.ref.WeakReference
+
+open class ActivityView(activity: Activity) {
+    private val activityRef: WeakReference<Activity> = WeakReference(activity)
+
+    val activity: Activity?
+        get() = activityRef.get()
+
+    val context: Context?
+        get() = activity
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,12 +18,11 @@
     <Button
         android:id="@+id/parking_size_button"
         style="@style/ConfigureParkingSizeButtonMainActivityStyle"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/txt_main_activity_parking_size_button_label"
-        android:layout_marginEnd="@dimen/parking_size_button_marginStart_marginEnd"
-        android:layout_marginStart="@dimen/parking_size_button_marginStart_marginEnd"
         android:layout_marginTop="@dimen/parking_size_button_marginTop"
+        android:text="@string/text_main_activity_parking_size_button_label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/title_main_activity" />
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,6 +2,5 @@
 <resources>
     <dimen name="size_main_activity_title">35sp</dimen>
     <dimen name="margin_top_main_activity_title">40dp</dimen>
-    <dimen name="parking_size_button_marginStart_marginEnd">80dp</dimen>
-    <dimen name="parking_size_button_marginTop">80dp</dimen>
+    <dimen name="parking_size_button_marginTop">40dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">ParkingSystem</string>
     <string name="title_main">Parking System</string>
-    <string name="txt_main_activity_parking_size_button_label">Configure parking size</string>
+    <string name="text_main_activity_parking_size_button_label">Configure parking size</string>
+    <string name="text_parking_size_toast">Total of parking lots: %1$d</string>
 </resources>


### PR DESCRIPTION
For adding the functionality to the parking size button, I implemented MVP pattern. Now, when you press this button, it shows a toast with the total of parking lots.

**Nexus S**
![image](https://user-images.githubusercontent.com/85899662/128771909-2460583b-97e3-4497-be04-b677ada32b86.png)

Pixel **3a**
![image](https://user-images.githubusercontent.com/85899662/128772046-dd704079-b0f2-4248-9f78-1fe7d99ce633.png)

Folder Structure
![image](https://user-images.githubusercontent.com/85899662/128772774-6c51c50f-f42d-4754-9dcd-34657a419466.png)
